### PR TITLE
Release 1.1 to support new token vending

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -40,4 +40,4 @@ jobs:
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - name: Testing CLI (Runs both unit and integration tests)
         run: |
-          coverage run --source=src -m pytest -v -s . && coverage report --show-missing --fail-under=53      
+          coverage run --source=src -m pytest -v -s . && coverage report --show-missing --fail-under=56

--- a/README.md
+++ b/README.md
@@ -12,9 +12,11 @@ At a high level, the component will do the following:
 4. Use the retrieved credentials to connect to InfluxDB.
 5. Set up a subscription to the `$local/greengrass/telemetry` topic and forward all telemetry messages to InfluxDB.
 
-This component works together with the `aws.greengrass.labs.database.InfluxDB` and `aws.greengrass.labs.dashboard.Grafana` components to persist and visualize Greengrass System Telemetry data.
+This component works together with the `aws.greengrass.labs.dashboard.GreengrassDashboard`<TODO>, `aws.greengrass.labs.database.InfluxDB` and `aws.greengrass.labs.dashboard.Grafana` components to persist and visualize Greengrass System Telemetry data.
+The `aws.greengrass.labs.dashboard.GreengrassDashboard` TODO component automates the setup of Grafana with InfluxDB to provide a "one-click" experience, but this component still needs to be configured first before creation. See the `Setup` section below for instructions.
 * [aws.greengrass.labs.database.InfluxDB](https://github.com/awslabs/aws-greengrass-labs-database-influxdb)
 * [aws.greengrass.labs.dashboard.Grafana](https://github.com/awslabs/aws-greengrass-labs-dashboard-grafana)
+* `aws.greengrass.labs.dashboard.GreengrassDashboard` TODO
 
 ## Configuration
 * `TokenRequestTopic`- the topic to send a request to in order to retrieve InfluxDB credentials
@@ -32,7 +34,7 @@ This component works together with the `aws.greengrass.labs.database.InfluxDB` a
 
 
 ## Setup
-* This component requires no additional setup, unless the request/response topics are modified in `aws.greengrass.labs.database.InfluxDB`
+* This component requires no additional configuration, unless the request/response topics are modified in `aws.greengrass.labs.database.InfluxDB`
 * When deployed, this component will automatically begin forwarding telemetry from the [Nucleus Telemetry Emitter component plugin](https://docs.aws.amazon.com/greengrass/v2/developerguide/nucleus-emitter-component.html).
   * Since the default publish interval for the Nucleus Telemetry Emitter is 60 seconds, you may want to configure that component during deployment to have a lower publish interval with a configuration update similar to the following (which sets it to 5 seconds). Note that smaller publish intervals may result in higher CPU usage on your device.
     ```
@@ -40,6 +42,24 @@ This component works together with the `aws.greengrass.labs.database.InfluxDB` a
     "telemetryPublishIntervalMs": "5000"
     }
     ```
+
+### Prerequisites
+1. Setup the GDK CLI, Greengrass, and `aws.greengrass.labs.database.InfluxDB` using [the instructions here](https://github.com/awslabs/aws-greengrass-labs-database-influxdb/blob/main/README.md#setup).
+
+### Component Setup
+2. Pull down the component in a new directory using the [GDK CLI](https://docs.aws.amazon.com/greengrass/v2/developerguide/install-greengrass-development-kit-cli.html).
+    ```
+   mkdir aws-greengrass-labs-telemetry-influxdbpublisher; cd aws-greengrass-labs-telemetry-influxdbpublisher
+   gdk component init --repository aws-greengrass-labs-telemetry-influxdbpublisher
+   ```
+3. Use the [GDK CLI](https://docs.aws.amazon.com/greengrass/v2/developerguide/greengrass-development-kit-cli.html) to build the component to prepare for publishing.
+   ```
+   gdk component build
+   ```
+4. Use the [GDK CLI](https://docs.aws.amazon.com/greengrass/v2/developerguide/greengrass-development-kit-cli.html) to create a private component.
+   ```
+   gdk component publish
+   ```
     
 ## Sending Custom Telemetry
 * This component listens to all telemetry on the `$local/greengrass/telemetry` topic and forwards it to InfluxDB.

--- a/recipe.yaml
+++ b/recipe.yaml
@@ -1,12 +1,12 @@
 ---
 RecipeFormatVersion: '2020-01-25'
 ComponentName: aws.greengrass.labs.telemetry.InfluxDBPublisher
-ComponentVersion: '1.0.0'
+ComponentVersion: '1.1.0'
 ComponentDescription: 'A component that relays and publishes telemetry from Greengrass to InfluxDB.'
 ComponentPublisher: Amazon
 ComponentDependencies:
     aws.greengrass.labs.database.InfluxDB:
-      VersionRequirement: "1.0.0"
+      VersionRequirement: "~1.1.0"
       DependencyType: HARD
     aws.greengrass.telemetry.NucleusEmitter:
       VersionRequirement: "1.0.1"

--- a/src/streamHandlers.py
+++ b/src/streamHandlers.py
@@ -31,9 +31,8 @@ class InfluxDBDataStreamHandler(client.SubscribeToTopicStreamHandler):
             None
         """
         try:
-            message = str(event.binary_message.message, "utf-8")
-            self.influxdb_parameters = json.loads(message)
-            if (len(self.influxdb_parameters) == 0):
+            self.influxdb_parameters = event.json_message.message
+            if len(self.influxdb_parameters) == 0:
                 raise ValueError("Retrieved Influxdb parameters are empty!")
         except Exception:
             logging.error('Failed to load telemetry event JSON!', exc_info=True)
@@ -87,7 +86,7 @@ class TelemetryStreamHandler(client.SubscribeToTopicStreamHandler):
                 self.influxdb_parameters['InfluxDBInterface'],
                 self.influxdb_parameters['InfluxDBPort']
             ),
-            token=self.influxdb_parameters['InfluxDBRWToken'],
+            token=self.influxdb_parameters['InfluxDBToken'],
             org=self.influxdb_parameters['InfluxDBOrg'],
             verify_ssl=ssl_verify
         )

--- a/test/test_influxDBTelemetryPublisher.py
+++ b/test/test_influxDBTelemetryPublisher.py
@@ -52,3 +52,17 @@ def test_retrieve_influxdb_params(InfluxDBDataStreamHandler, mocker):
     import src.influxDBTelemetryPublisher as publisher
     params = publisher.retrieve_influxdb_params("test/topic", "test/topic")
     assert json.loads(params) == testparams
+
+
+@patch('streamHandlers.InfluxDBDataStreamHandler')
+def test_fail_to_retrieve_influxdb_params(InfluxDBDataStreamHandler, mocker):
+
+    mocker.patch("awsiot.greengrasscoreipc.connect")
+    handler = InfluxDBDataStreamHandler()
+    handler.influxdb_parameters = None
+    import src.influxDBTelemetryPublisher as publisher
+    mocker.patch("src.influxDBTelemetryPublisher.publish_token_request", side_effect=ValueError("test"))
+    with pytest.raises(SystemExit) as e:
+        publisher.retrieve_influxdb_params("test/topic", "test/topic")
+        assert e.type == SystemExit
+        assert e.value.code == 1

--- a/test/test_streamHandlers.py
+++ b/test/test_streamHandlers.py
@@ -8,6 +8,7 @@ from unittest.mock import patch, ANY
 import src.streamHandlers as streamHandler
 
 from awsiot.greengrasscoreipc.model import (
+    JsonMessage,
     BinaryMessage,
     SubscriptionResponseMessage
 )
@@ -20,17 +21,18 @@ testparams = {
     'InfluxDBBucket': 'greengrass-telemetry',
     'InfluxDBPort': '8086',
     'InfluxDBInterface': '127.0.0.1',
-    'InfluxDBRWToken': 'vb53ZyYlxJjAeWcDbgPjbNvkvdD95b2hCrt0CoaZyEL5QYBiQfLw3TbgqgDozj74_aZ9pYCwVJM6Vj5quLAfSA==',
+    'InfluxDBToken': 'vb53ZyYlxJjAeWcDbgPjbNvkvdD95b2hCrt0CoaZyEL5QYBiQfLw3TbgqgDozj74_aZ9pYCwVJM6Vj5quLAfSA==',
     'InfluxDBServerProtocol': 'https',
-    'InfluxDBSkipTLSVerify': 'true'
+    'InfluxDBSkipTLSVerify': 'true',
+    'InfluxDBTokenAccessType': 'RW'
 }
 
 
 def test_validInfluxDBParams(mocker):
 
     handler = streamHandler.InfluxDBDataStreamHandler()
-    binary_message = BinaryMessage(message=str.encode(json.dumps(testparams)))
-    response_message = SubscriptionResponseMessage(binary_message=binary_message)
+    message = JsonMessage(message=testparams)
+    response_message = SubscriptionResponseMessage(json_message=message)
     handler.on_stream_event(response_message)
     assert handler.influxdb_parameters == testparams
 
@@ -41,8 +43,8 @@ def test_invalidInfluxDBParams(mocker):
     emptyparams = {}
 
     handler = streamHandler.InfluxDBDataStreamHandler()
-    binary_message = BinaryMessage(message=str.encode(json.dumps(emptyparams)))
-    response_message = SubscriptionResponseMessage(binary_message=binary_message)
+    message = JsonMessage(message=emptyparams)
+    response_message = SubscriptionResponseMessage(json_message=message)
     with pytest.raises(SystemExit) as pytest_wrapped_e:
         handler.on_stream_event(response_message)
         assert pytest_wrapped_e.type == SystemExit


### PR DESCRIPTION
**Description of changes:**

* Create and vend multiple tokens instead of just RW (RO, RW, admin)
* Various cleanup and bug fixes
* Increased testing coverage, from 53 -> 56
* This is NOT backwards compatible (new version 1.1.0)

**Why is this change necessary:**
* To support a one-click dashboard
**How was this change tested:**
* End-to-end deployments with Grafana in various configurations (different ports, http/https, etc.)
**Any additional information or context required to review the change:**

**Checklist:**
- [x] Updated the README if applicable
- [x] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.