### PR TITLE
v2.0.0 to support vending multiple tokens and dashboard. 

### DIFF
--- a/gdk-config.json
+++ b/gdk-config.json
@@ -2,7 +2,7 @@
   "component" :{
     "aws.greengrass.labs.telemetry.InfluxDBPublisher": {
       "author": "AWS IoT Greengrass",
-      "version": "NEXT_PATCH",
+      "version": "2.0.0",
       "build": {
         "build_system": "zip"
       },

--- a/recipe.yaml
+++ b/recipe.yaml
@@ -1,12 +1,12 @@
 ---
 RecipeFormatVersion: '2020-01-25'
 ComponentName: aws.greengrass.labs.telemetry.InfluxDBPublisher
-ComponentVersion: '1.1.0'
+ComponentVersion: '2.0.0'
 ComponentDescription: 'A component that relays and publishes telemetry from Greengrass to InfluxDB.'
 ComponentPublisher: Amazon
 ComponentDependencies:
     aws.greengrass.labs.database.InfluxDB:
-      VersionRequirement: "~1.1.0"
+      VersionRequirement: "~2.0.0"
       DependencyType: HARD
     aws.greengrass.telemetry.NucleusEmitter:
       VersionRequirement: "1.0.1"


### PR DESCRIPTION
Version bump to 2.0.0.

BREAKING CHANGE: InfluxDB IPC token vending


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.