### PR TITLE
Refactored the logic for processing tokens obtained from aws-greengrass-labs-database-influxdb

### DIFF
--- a/src/influxDBTelemetryPublisher.py
+++ b/src/influxDBTelemetryPublisher.py
@@ -118,21 +118,14 @@ def retrieve_influxdb_params(publish_topic, subscribe_topic) -> str:
     ipc_publisher_client = awsiot.greengrasscoreipc.connect()
     retries = 0
     try:
-        # Retrieve the InfluxDB parameters to connect
-        # Retry 10 times or until we retrieve parameters with RW access
+        # Retrieve InfluDB parameters to connect; retry up to 10 times
         while not handler.influxdb_parameters and retries < 10:
             logging.info("Publish attempt {}".format(retries))
             publish_token_request(ipc_publisher_client, publish_topic)
             logging.info('Successfully published token request to topic: {}'.format(publish_topic))
             retries += 1
-            logging.info('Waiting for 10 seconds...')
-            time.sleep(10)
-            if handler.influxdb_parameters:
-                # This component should only accept tokens with RW access, and will reject others in case of conflict
-                if handler.influxdb_parameters['InfluxDBTokenAccessType'] != "RW":
-                    logging.warning("Discarding retrieved token with incorrect access level {}"
-                                    .format(handler.influxdb_parameters['InfluxDBTokenAccessType']))
-                    handler.influxdb_parameters = {}
+            time.sleep(2)
+
     except Exception:
         logging.error("Received error while sending token publish request!", exc_info=True)
     finally:

--- a/src/streamHandlers.py
+++ b/src/streamHandlers.py
@@ -31,9 +31,16 @@ class InfluxDBDataStreamHandler(client.SubscribeToTopicStreamHandler):
             None
         """
         try:
-            self.influxdb_parameters = event.json_message.message
-            if len(self.influxdb_parameters) == 0:
+            p = event.json_message.message
+            if len(p) == 0:
                 raise ValueError("Retrieved Influxdb parameters are empty!")
+            # accept only tokens with RW access; reject all others
+            if p['InfluxDBTokenAccessType'] != 'RW':
+                logging.warning("Discarding retrieved token with incorrect access level {}"
+                                .format(p['InfluxDBTokenAccessType']))
+            else:
+                self.influxdb_parameters = p
+
         except Exception:
             logging.error('Failed to load telemetry event JSON!', exc_info=True)
             exit(1)


### PR DESCRIPTION
Refactored the logic for processing tokens obtained from aws-greengrass-labs-database-influxdb; this has now moved from the time-driven loop that publishes requests to the stream handler receiving them.

**Issue #, if available:**
None

**Description of changes:**
Moved processing of InfluxDB tokens from the time-driven loop that publishes requests to the stream handler receiving token responses.

**Why is this change necessary:**
Subsequent calls to the stream handler overwrite legitimate responses previously received. The approach worked when requests originated from one client at a time but quickly broke down otherwise. Furthermore, it is conceptually wrong to process InfluxDB tokens in the time-driven loop that publishes requests as opposed to the stream handler receiving them.

**How was this change tested:**
Using up to three clients requesting InfluxDB connection tokens simultaneously.

**Any additional information or context required to review the change:**
None

**Checklist:**
- [  ] Updated the README if applicable
- [  ] Updated or added new unit tests
- [  ] Updated or added new integration tests
- [  ] Updated or added new end-to-end tests
- [  ] If your code makes a remote network call, it was tested with a proxy
- [X ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.