### PR TITLE
updated code with request_id parameter for token vending request

### DIFF
--- a/gdk-config.json
+++ b/gdk-config.json
@@ -2,7 +2,7 @@
   "component" :{
     "aws.greengrass.labs.telemetry.InfluxDBPublisher": {
       "author": "AWS IoT Greengrass",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "build": {
         "build_system": "zip"
       },

--- a/recipe.yaml
+++ b/recipe.yaml
@@ -1,12 +1,12 @@
 ---
 RecipeFormatVersion: '2020-01-25'
 ComponentName: aws.greengrass.labs.telemetry.InfluxDBPublisher
-ComponentVersion: '2.0.0'
+ComponentVersion: '2.1.0'
 ComponentDescription: 'A component that relays and publishes telemetry from Greengrass to InfluxDB.'
 ComponentPublisher: Amazon
 ComponentDependencies:
     aws.greengrass.labs.database.InfluxDB:
-      VersionRequirement: "~2.0.0"
+      VersionRequirement: "~2.1.0"
       DependencyType: HARD
     aws.greengrass.telemetry.NucleusEmitter:
       VersionRequirement: "1.0.1"

--- a/src/influxDBTelemetryPublisher.py
+++ b/src/influxDBTelemetryPublisher.py
@@ -61,7 +61,7 @@ def publish_token_request(ipc_publisher_client, publish_topic) -> None:
     request = PublishToTopicRequest()
     request.topic = publish_topic
     publish_message = PublishMessage()
-    publish_message.json_message = JsonMessage(message={"action": "RetrieveToken",  "accessLevel": "RW"})
+    publish_message.json_message = JsonMessage(message={"action": "RetrieveToken",  "accessLevel": "RW", 'request_id': streamHandlers.REQUEST_ID})
     request.publish_message = publish_message
     publish_operation = ipc_publisher_client.new_publish_to_topic()
     try:

--- a/src/streamHandlers.py
+++ b/src/streamHandlers.py
@@ -12,6 +12,7 @@ from awsiot.greengrasscoreipc.model import (
     SubscriptionResponseMessage
 )
 
+REQUEST_ID = 'aws-greengrass-labs-telemetry-influxdbpublisher'
 
 class InfluxDBDataStreamHandler(client.SubscribeToTopicStreamHandler):
     def __init__(self):
@@ -31,9 +32,11 @@ class InfluxDBDataStreamHandler(client.SubscribeToTopicStreamHandler):
             None
         """
         try:
-            self.influxdb_parameters = event.json_message.message
-            if len(self.influxdb_parameters) == 0:
-                raise ValueError("Retrieved Influxdb parameters are empty!")
+            if ('request_id' in event.json_message.message):
+                if event.json_message.message['request_id'] == REQUEST_ID:
+                    self.influxdb_parameters = event.json_message.message
+                    if len(self.influxdb_parameters) == 0:
+                        raise ValueError("Retrieved Influxdb parameters are empty!")
         except Exception:
             logging.error('Failed to load telemetry event JSON!', exc_info=True)
             exit(1)


### PR DESCRIPTION
Added request_id for token retrieval mechanism.

Issue #, if available:
None

Description of changes:
Adding a unique request_id to the token request, allow for multiple component to ask for different level of token without impact others.

Why is this change necessary:
If two or more component request for a token, the same response is sent to all components which would treat response as invalid and repeat the request token over and over.

How was this change tested:
Using up to three clients requesting InfluxDB connection tokens simultaneously.

Any additional information or context required to review the change:
None

Checklist:

    [X] Updated the README if applicable
    [ ] Updated or added new unit tests
    [ ] Updated or added new integration tests
    [ ] Updated or added new end-to-end tests
    [ ] If your code makes a remote network call, it was tested with a proxy
    [X] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
